### PR TITLE
Update function.lookup.php

### DIFF
--- a/Classes/SmartyPlugins/Frontend/function.lookup.php
+++ b/Classes/SmartyPlugins/Frontend/function.lookup.php
@@ -84,7 +84,7 @@ function executeQuery($lookupValue, $lookupField, $returnFields, $table)
 {
     $lookupResult = false;
 
-    $where = mysql_real_escape_string($lookupField) . ' = :lookupValue';
+    $where = mysqli_real_escape_string($lookupField) . ' = :lookupValue';
     if (isset($GLOBALS['TCA'][$table]['ctrl'])) {
         $where .= $GLOBALS['TSFE']->sys_page->enableFields($table);
     }


### PR DESCRIPTION
Change mysql_real_escape_string to mysqli_real_escape_string
to make use of the mysqli function (required for TYPO3 6.2 LTS) 
mysqli_real_escape_string needs an existing connection. From my code understanding this should always be the case here.
